### PR TITLE
BUGFIX: Catch exception in detectContentStream()

### DIFF
--- a/Classes/Http/DetectContentSubgraphComponent.php
+++ b/Classes/Http/DetectContentSubgraphComponent.php
@@ -185,8 +185,8 @@ final class DetectContentSubgraphComponent implements Http\Component\ComponentIn
         $requestPath = $componentContext->getHttpRequest()->getUri()->getPath();
         $requestPath = mb_substr($requestPath, mb_strrpos($requestPath, '/'));
         if ($requestPath !== '' && NodePaths::isContextPath($requestPath)) {
-            $nodePathAndContext = NodePaths::explodeContextPath($requestPath);
             try {
+                $nodePathAndContext = NodePaths::explodeContextPath($requestPath);
                 $contentStreamIdentifier = $nodePathAndContext['workspaceName'];
             } catch (\InvalidArgumentException $exception) {
             }


### PR DESCRIPTION
When `isContextPath` said "yes", but `explodeContextPath` disagreed,
the resulting `InvalidArgumentException` was not caught (as intended),
but instead thrown and logged. This fixes it.

This happens with URLs like `…/Logo_1zeilig_300x33px_RGB@2x.png`
since there's an `@` in there…