### PR TITLE
TASK: fix documentation of DetectContentSubgraphMiddleware registration

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -248,11 +248,9 @@ Detection is done via an HTTP middleware that can be replaced via configuration:
    Neos:
      Flow:
        http:
-         chain:
-           preprocess:
-             chain:
-               detectContentSubgraph:
-                 component: Flowpack\Neos\DimensionResolver\Http\DetectContentSubgraphMiddleware
+         middlewares:
+           detectContentSubgraph:
+             middleware: Flowpack\Neos\DimensionResolver\Http\DetectContentSubgraphMiddleware
 
 Link processing is done by the ``Flowpack\Neos\DimensionResolver\Http\ContentSubgraphUriProcessorInterface``. To introduce your custom behaviour,
 implement the interface and declare it in ``Objects.yaml`` as usual in Flow.


### PR DESCRIPTION
The package itself registers the middleware correctly:
https://github.com/Flowpack/neos-dimensionresolver/blob/master/Configuration/Settings.yaml
But the documentation is not correct.