### PR TITLE
BUGFIX: Respect the configured value for uriPathSuffix

### DIFF
--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -282,6 +282,10 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         $routePath = $this->resolveRoutePathForNode($node);
         $uriConstraints = $this->contentSubgraphUriProcessor->resolveDimensionUriConstraints($node);
 
+        if (isset($this->options['uriPathSuffix'])) {
+            $uriConstraints = $uriConstraints->withPathSuffix($this->options['uriPathSuffix']);
+        }
+
         return new ResolveResult($routePath, $uriConstraints);
     }
 

--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -172,6 +172,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      * @throws Exception\NoSuchNodeException
      * @throws Exception\NoWorkspaceException
      * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws Exception\InvalidRequestPathException
      */
     protected function convertRequestPathToNode($requestPath)
     {
@@ -197,6 +198,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         if ($requestPathWithoutContext === '') {
             $node = $siteNode;
         } else {
+            $requestPathWithoutContext = $this->truncateUriPathSuffix((string)$requestPathWithoutContext);
             $relativeNodePath = $this->getRelativeNodePathByUriPathSegmentProperties($siteNode, $requestPathWithoutContext);
             $node = ($relativeNodePath !== false) ? $siteNode->getNode($relativeNodePath) : null;
         }
@@ -206,6 +208,26 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         }
 
         return $node;
+    }
+
+    /**
+     * Removes the configured suffix from the given $uriPath
+     * If the "uriPathSuffix" option is not set (or set to an empty string) the unaltered $uriPath is returned
+     *
+     * @param string $uriPath
+     * @return false|string|null
+     * @throws Exception\InvalidRequestPathException
+     */
+    protected function truncateUriPathSuffix(string $uriPath)
+    {
+        if (empty($this->options['uriPathSuffix'])) {
+            return $uriPath;
+        }
+        $suffixLength = strlen($this->options['uriPathSuffix']);
+        if (substr($uriPath, -$suffixLength) !== $this->options['uriPathSuffix']) {
+            throw new Exception\InvalidRequestPathException(sprintf('The request path "%s" doesn\'t contain the configured uriPathSuffix "%s"', $uriPath, $this->options['uriPathSuffix']), 1604912439);
+        }
+        return substr($uriPath, 0, -$suffixLength);
     }
 
     /**

--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -282,7 +282,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
         $routePath = $this->resolveRoutePathForNode($node);
         $uriConstraints = $this->contentSubgraphUriProcessor->resolveDimensionUriConstraints($node);
 
-        if (isset($this->options['uriPathSuffix'])) {
+        if (isset($this->options['uriPathSuffix']) && $node !== $siteNode) {
             $uriConstraints = $uriConstraints->withPathSuffix($this->options['uriPathSuffix']);
         }
 


### PR DESCRIPTION
When using this package, routing is defaulted to routes without appending the chosen uriPathSuffix.

This fix adds the missing check for uriPathSuffix the same way as it is done in `Neos\Neos\Routing\FrontendNodeRoutePartHandler`