### PR TITLE
TASK: Update FrontendNodeRoutePartHandler to current "original"

### DIFF
--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -181,6 +181,8 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      *
      * @param string $requestPath The request path, for example /the/node/path@some-workspace
      * @return NodeInterface
+     * @throws IllegalObjectTypeException
+     * @throws InvalidRequestPathException
      * @throws NoSiteException
      * @throws NoSiteNodeException
      * @throws NoSuchNodeException
@@ -237,7 +239,7 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
      *
      * @param NodeInterface|string|string[] $node Either a Node object or an absolute context node path (potentially wrapped in an array as ['__contextNodePath' => '<value>'])
      * @return bool|ResolveResult An instance of ResolveResult if the route could resolve the $node, otherwise FALSE. @see DynamicRoutePart::resolveValue()
-     * @throws MissingNodePropertyException | NeosException | IllegalObjectTypeException | NodeException
+     * @throws MissingNodePropertyException | NeosException | IllegalObjectTypeException
      * @see NodeIdentityConverterAspect
      */
     protected function resolveValue($node)

--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -279,6 +279,11 @@ class FrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendN
 
         $uriConstraints = $this->contentSubgraphUriProcessor->resolveDimensionUriConstraints($nodeOrUri);
         $uriPath = $this->resolveRoutePathForNode($nodeOrUri);
+
+        if (!empty($this->options['uriPathSuffix']) && $node->getParentPath() !== SiteService::SITES_ROOT_PATH) {
+            $uriConstraints = $uriConstraints->withPathSuffix($this->options['uriPathSuffix']);
+        }
+
         return new ResolveResult($uriPath, $uriConstraints);
     }
 

--- a/Classes/Routing/FrontendNodeRoutePartHandler.php
+++ b/Classes/Routing/FrontendNodeRoutePartHandler.php
@@ -43,6 +43,7 @@ use Neos\Neos\Routing\Exception\NoHomepageException;
 use Neos\Neos\Routing\Exception\NoSiteException;
 use Neos\Neos\Routing\Exception\NoSuchNodeException;
 use Neos\Neos\Routing\Exception\NoWorkspaceException;
+use Neos\Neos\Routing\Exception\NoSiteNodeException;
 use Neos\Neos\Routing\FrontendNodeRoutePartHandlerInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "license": "GPL-3.0+",
     "description": "A support package for Neos CMS that allows for arbitrary content dimension resolution.",
     "require": {
-        "neos/neos": "^7.0 || ^8.0 || dev-master",
-        "neos/flow": "^7.0 || ^8.0 || dev-master"
+        "neos/neos": "^8.0",
+        "neos/flow": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-3.0+",
     "description": "A support package for Neos CMS that allows for arbitrary content dimension resolution.",
     "require": {
+        "ext-mbstring": "*",
         "neos/neos": "^8.0",
         "neos/flow": "^8.0"
     },


### PR DESCRIPTION
The FrontendNodeRoutePartHandler lacked quite some changes from the implementation in Neos, and thus

- did not resolve shortcuts directly to their target
- did not know about the `nodeType` options

Also the exception codes have been "uniqueified".