### PR TITLE
FIX: Specify package for config injection

### DIFF
--- a/Classes/Http/ContentSubgraphUriProcessor.php
+++ b/Classes/Http/ContentSubgraphUriProcessor.php
@@ -37,7 +37,7 @@ final class ContentSubgraphUriProcessor implements ContentSubgraphUriProcessorIn
     protected $dimensionPresetLinkProcessorResolver;
 
     /**
-     * @Flow\InjectConfiguration("routing.supportEmptySegmentForDimensions")
+     * @Flow\InjectConfiguration(package="Neos.Neos", path="routing.supportEmptySegmentForDimensions")
      * @var boolean
      */
     protected $supportEmptySegmentForDimensions;


### PR DESCRIPTION
The config injection is missing the package name and an error is thrown if using an empty resolution value with the URI path segment resolution.